### PR TITLE
refactor: add projectId to Log entity and update related persistence logic

### DIFF
--- a/src/main/java/com/develop/logsentry/common/exception/CustomException.java
+++ b/src/main/java/com/develop/logsentry/common/exception/CustomException.java
@@ -6,19 +6,13 @@ import lombok.Getter;
 public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
     private final Object[] args;
+    private final Long projectId;
 
-    public CustomException(ErrorCode errorCode, Object... args) {
+    public CustomException(ErrorCode errorCode, Long projectId, Object... args) {
         super(errorCode.getFormattedMessage(args));
         this.errorCode = errorCode;
         this.args = args;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
-
-    public Object[] getArgs() {
-        return args;
+        this.projectId = projectId;
     }
 
     public String getSource() {

--- a/src/main/java/com/develop/logsentry/common/exception/ErrorCode.java
+++ b/src/main/java/com/develop/logsentry/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, LogLevel.WARN, "%s을(를) 찾지못했습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, LogLevel.ERROR, "비밀번호가 올바르지 않습니다."),
     EMAIL_NOT_MATCH(HttpStatus.CONFLICT, LogLevel.WARN, "Email이 맞지 않습니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, LogLevel.WARN, "로그 조회는 관리자, 해당 프로젝트 생성자, 팀 생성자만 가능합니다."),
     INVALID_INVITATION_TOKEN(HttpStatus.UNAUTHORIZED, LogLevel.ERROR, "토큰이 유효하지 않습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/develop/logsentry/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/develop/logsentry/common/exception/GlobalExceptionHandler.java
@@ -18,50 +18,57 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
-        sendLogToKafka(
-                ex.getErrorCode().getLogLevel(),
-                ex,
-                ex.getSource(),
-                ex.getErrorCode().name()
-        );
-        return new ResponseEntity<>(
-                ErrorResponse.from(ex.getErrorCode(), ex.getArgs()),
-                ex.getErrorCode().getStatus()
-        );
+        Long projectId = ex.getProjectId();
+        sendLogToKafka(projectId, ex.getErrorCode().getLogLevel(), ex, ex.getSource(), ex.getErrorCode().name());
+
+        return new ResponseEntity<>(ErrorResponse.from(ex.getErrorCode(), ex.getArgs()), ex.getErrorCode().getStatus());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        sendLogToKafka(LogLevel.ERROR, ex, "global", "GLOBAL_EXCEPTION");
+        sendLogToKafka(null, LogLevel.ERROR, ex, "global", "GLOBAL_EXCEPTION");
+
         return getErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        sendLogToKafka(LogLevel.WARN, ex, "validation", "VALIDATION_ERROR");
+        sendLogToKafka(null, LogLevel.WARN, ex, "validation", "VALIDATION_ERROR");
         String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
         return getErrorResponse(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
-        sendLogToKafka(LogLevel.WARN, ex, "security", "ACCESS_DENIED");
+        sendLogToKafka(null, LogLevel.WARN, ex, "security", "ACCESS_DENIED"
+        );
         return getErrorResponse(HttpStatus.FORBIDDEN, "접근이 거부되었습니다.");
     }
 
-    private void sendLogToKafka(LogLevel logLevel, Exception ex, String source, String errorCategory) {
+    private void sendLogToKafka(Long projectId, LogLevel logLevel, Exception ex, String source, String errorCategory) {
         String exceptionName = ex.getClass().getSimpleName();
-        String errorCodeMessage = null;
+        String errorCodeMessage;
 
         if (ex instanceof CustomException customEx) {
             errorCodeMessage = customEx.getErrorCode().name() + ": " + customEx.getErrorCode().getMessage();
         } else {
             errorCodeMessage = exceptionName;
         }
+
         String message = ex.getMessage();
         String stackSummary = getStackTraceSummary(ex);
 
-        logProducer.sendLog(logLevel, exceptionName, errorCodeMessage, message, stackSummary, source, errorCategory);
+        logProducer.sendLog(
+                projectId,
+                logLevel,
+                exceptionName,
+                errorCodeMessage,
+                message,
+                stackSummary,
+                source,
+                errorCategory
+        );
     }
 
     private String getStackTraceSummary(Exception ex) {

--- a/src/main/java/com/develop/logsentry/domain/log/controller/LogController.java
+++ b/src/main/java/com/develop/logsentry/domain/log/controller/LogController.java
@@ -1,5 +1,6 @@
 package com.develop.logsentry.domain.log.controller;
 
+import com.develop.logsentry.common.security.UserDetailsImpl;
 import com.develop.logsentry.domain.log.dto.response.LogResponseDto;
 import com.develop.logsentry.domain.log.dto.response.LogStatisticsDto;
 import com.develop.logsentry.domain.log.entity.LogLevel;
@@ -8,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -24,25 +25,31 @@ public class LogController {
     // 로그 조건 검색
     @GetMapping
     public ResponseEntity<Page<LogResponseDto>> getLogs(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) LogLevel logLevel,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        return ResponseEntity.status(HttpStatus.OK).body(logService.getLogs(logLevel, start, end, page, size));
+
+        return ResponseEntity.status(HttpStatus.OK).body(logService.getLogs(userDetails.getUser(), projectId, logLevel, start, end, page, size));
     }
 
     // 로그 상세 조회
     @GetMapping("/{id}")
-    public ResponseEntity<LogResponseDto> getLogDetail(@PathVariable Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(logService.getLogDetail(id));
+    public ResponseEntity<LogResponseDto> getLogDetail(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
+        return ResponseEntity.status(HttpStatus.OK).body(logService.getLogDetail(userDetails.getUser(), id));
     }
 
     // 로그 통계 조회
     @GetMapping("/statistics")
     public ResponseEntity<List<LogStatisticsDto>> getStatistics(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) Long projectId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-        return ResponseEntity.status(HttpStatus.OK).body(logService.getLogStatistics(start, end));
+
+        return ResponseEntity.status(HttpStatus.OK).body(logService.getLogStatistics(userDetails.getUser(), projectId, start, end));
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/log/dto/request/LogMessageDto.java
+++ b/src/main/java/com/develop/logsentry/domain/log/dto/request/LogMessageDto.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @Getter
 @Builder
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
 public class LogMessageDto {
+    private final Long projectId;
     private final LogLevel logLevel;
     private final String exceptionName;
     private final String errorCodeMessage;
@@ -23,9 +23,10 @@ public class LogMessageDto {
     private final LocalDateTime timestamp;
     private final String errorCategory;
 
-    public static LogMessageDto of(LogLevel logLevel, String exceptionName, String errorCodeMessage,
+    public static LogMessageDto of(Long projectId, LogLevel logLevel, String exceptionName, String errorCodeMessage,
                                    String message, String stackSummary, String source, String errorCategory) {
         return LogMessageDto.builder()
+                .projectId(projectId)
                 .logLevel(logLevel)
                 .exceptionName(exceptionName)
                 .errorCodeMessage(errorCodeMessage)

--- a/src/main/java/com/develop/logsentry/domain/log/dto/response/LogResponseDto.java
+++ b/src/main/java/com/develop/logsentry/domain/log/dto/response/LogResponseDto.java
@@ -1,5 +1,6 @@
 package com.develop.logsentry.domain.log.dto.response;
 
+import com.develop.logsentry.domain.log.entity.Log;
 import com.develop.logsentry.domain.log.entity.LogLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,4 +17,16 @@ public class LogResponseDto {
     private String message;
     private String stackSummary;
     private LocalDateTime timestamp;
+
+    public static LogResponseDto from(Log log) {
+        return new LogResponseDto(
+                log.getId(),
+                log.getLogLevel(),
+                log.getExceptionName(),
+                log.getErrorCodeMessage(),
+                log.getMessage(),
+                log.getStackSummary(),
+                log.getTimestamp()
+        );
+    }
 }

--- a/src/main/java/com/develop/logsentry/domain/log/entity/Log.java
+++ b/src/main/java/com/develop/logsentry/domain/log/entity/Log.java
@@ -33,5 +33,8 @@ public class Log {
     @Column(columnDefinition = "TEXT")
     private String stackSummary;      // ex: CustomException at com.example.user.UserService.findUser(UserService.java:57)
 
+    @Column(name = "project_id", nullable = true)  // 기존 프로젝트 ID 컬럼 그대로 사용
+    private Long projectIdLegacy;
+
     private LocalDateTime timestamp;  // ex: 2025-06-18T15:30:00
 }

--- a/src/main/java/com/develop/logsentry/domain/log/repository/LogRepository.java
+++ b/src/main/java/com/develop/logsentry/domain/log/repository/LogRepository.java
@@ -18,15 +18,29 @@ import java.util.Optional;
 @Repository
 public interface LogRepository extends JpaRepository<Log, Long> {
     Optional<Log> findById(Long id);
+    long countByProjectIdLegacyAndTimestampAfter(Long projectIdLegacy, LocalDateTime after);
 
     default Log findByIdOrThrow(Long id) {
-        return findById(id).orElseThrow(() -> new CustomException(ErrorCode.LOG_NOT_FOUND, "LOG", id));
+        return findById(id).orElseThrow(() -> new CustomException(ErrorCode.LOG_NOT_FOUND, null, "LOG", id));
     }
 
+    // 전체 로그 조회
     Page<Log> findByLogLevelAndTimestampBetween(LogLevel logLevel, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
     Page<Log> findByTimestampBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
 
+    // 프로젝트별 필터링
+    Page<Log> findByProjectIdLegacyAndLogLevelAndTimestampBetween(Long projectIdLegacy, LogLevel logLevel, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    Page<Log> findByProjectIdLegacyAndTimestampBetween(Long projectIdLegacy, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    // 전체 로그 레벨별 통계
     @Query("SELECT l.logLevel, COUNT(l) FROM Log l WHERE l.timestamp BETWEEN :start AND :end GROUP BY l.logLevel")
     List<Object[]> countGroupByLogLevel(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // 프로젝트별 로그 레벨 통계
+    @Query("SELECT l.logLevel, COUNT(l) FROM Log l WHERE l.projectIdLegacy = :projectId AND l.timestamp BETWEEN :start AND :end GROUP BY l.logLevel")
+    List<Object[]> countGroupByProjectIdAndLogLevel(@Param("projectId") Long projectId,
+                                                    @Param("start") LocalDateTime start,
+                                                    @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/develop/logsentry/domain/log/service/LogConsumer.java
+++ b/src/main/java/com/develop/logsentry/domain/log/service/LogConsumer.java
@@ -3,6 +3,7 @@ package com.develop.logsentry.domain.log.service;
 import com.develop.logsentry.domain.log.dto.request.LogMessageDto;
 import com.develop.logsentry.domain.log.entity.Log;
 import com.develop.logsentry.domain.log.repository.LogRepository;
+import com.develop.logsentry.domain.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -14,10 +15,23 @@ import org.springframework.stereotype.Component;
 public class LogConsumer {
 
     private final LogRepository logRepository;
+    private final ProjectRepository projectRepository;
 
     @KafkaListener(topics = "logs-topic", groupId = "log_group")
     public void consume(LogMessageDto dto) {
         try {
+            Long projectId = null;
+            if (dto.getProjectId() != null) {
+                boolean exists = projectRepository.existsById(dto.getProjectId());
+                log.info("dto.getProjectId() = {}", dto.getProjectId());
+                if (exists) {
+                    projectId = dto.getProjectId();
+                    log.info("Kafka Log 저장 시 Project ID {} -> 존재", dto.getProjectId());
+                } else {
+                    log.info("Kafka Log 저장 시 Project ID {} -> NULL", dto.getProjectId());
+                }
+            }
+
             Log log = Log.builder()
                     .logLevel(dto.getLogLevel())
                     .exceptionName(dto.getExceptionName())
@@ -25,6 +39,7 @@ public class LogConsumer {
                     .message(dto.getMessage())
                     .stackSummary(dto.getStackSummary())
                     .timestamp(dto.getTimestamp())
+                    .projectIdLegacy(projectId)  // project 대신 ID만 넣음
                     .build();
 
             logRepository.save(log);

--- a/src/main/java/com/develop/logsentry/domain/log/service/LogProducer.java
+++ b/src/main/java/com/develop/logsentry/domain/log/service/LogProducer.java
@@ -12,11 +12,10 @@ public class LogProducer {
     private static final String TOPIC = "logs-topic";
     private final KafkaTemplate<String, LogMessageDto> kafkaTemplate;
 
-    public void sendLog(LogLevel logLevel, String exceptionName, String errorCodeMessage, String message,
-            String stackSummary, String source, String errorCategory)
-    {
-        LogMessageDto logMessage = LogMessageDto.of(logLevel, exceptionName, errorCodeMessage, message,
-                stackSummary, source, errorCategory);
+    public void sendLog(Long projectId, LogLevel logLevel, String exceptionName, String errorCodeMessage,
+                        String message, String stackSummary, String source, String errorCategory) {
+        LogMessageDto logMessage = LogMessageDto.of(projectId, logLevel, exceptionName, errorCodeMessage,
+                message, stackSummary, source, errorCategory);
         kafkaTemplate.send(TOPIC, logMessage);
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/log/service/LogService.java
+++ b/src/main/java/com/develop/logsentry/domain/log/service/LogService.java
@@ -1,10 +1,17 @@
 package com.develop.logsentry.domain.log.service;
 
+import com.develop.logsentry.common.exception.CustomException;
+import com.develop.logsentry.common.exception.ErrorCode;
 import com.develop.logsentry.domain.log.dto.response.LogResponseDto;
 import com.develop.logsentry.domain.log.dto.response.LogStatisticsDto;
 import com.develop.logsentry.domain.log.entity.Log;
 import com.develop.logsentry.domain.log.entity.LogLevel;
 import com.develop.logsentry.domain.log.repository.LogRepository;
+import com.develop.logsentry.domain.project.entity.Project;
+import com.develop.logsentry.domain.project.repository.ProjectRepository;
+import com.develop.logsentry.domain.team.entity.TeamRole;
+import com.develop.logsentry.domain.user.entity.User;
+import com.develop.logsentry.domain.user.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,9 +29,12 @@ import java.util.List;
 public class LogService {
 
     private final LogRepository logRepository;
+    private final ProjectRepository projectRepository;
 
     /** 로그 조건 검색
      *
+     * @param user
+     * @param projectId
      * @param logLevel
      * @param start
      * @param end
@@ -32,56 +42,108 @@ public class LogService {
      * @param size
      * @return Page<LogResponseDto>
      */
-    public Page<LogResponseDto> getLogs(LogLevel logLevel, LocalDateTime start, LocalDateTime end, int page, int size) {
+    public Page<LogResponseDto> getLogs(User user, Long projectId, LogLevel logLevel, LocalDateTime start, LocalDateTime end, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("timestamp").descending());
-
         Page<Log> logs;
-        if (logLevel != null) {
-            logs = logRepository.findByLogLevelAndTimestampBetween(logLevel, start, end, pageable);
+
+        if (projectId == null) {
+            checkAdminRole(user);
+
+            logs = (logLevel != null)
+                    ? logRepository.findByLogLevelAndTimestampBetween(logLevel, start, end, pageable)
+                    : logRepository.findByTimestampBetween(start, end, pageable);
+
         } else {
-            logs = logRepository.findByTimestampBetween(start, end, pageable);
+            Project project = getProjectAllowDeleted(projectId);
+            checkAccessToProjectLogs(user, project);
+
+            logs = (logLevel != null)
+                    ? logRepository.findByProjectIdLegacyAndLogLevelAndTimestampBetween(projectId, logLevel, start, end, pageable)
+                    : logRepository.findByProjectIdLegacyAndTimestampBetween(projectId, start, end, pageable);
         }
 
-        return logs.map(log -> new LogResponseDto(
-                log.getId(),
-                log.getLogLevel(),
-                log.getExceptionName(),
-                log.getErrorCodeMessage(),
-                log.getMessage(),
-                log.getStackSummary(),
-                log.getTimestamp()
-        ));
+        return logs.map(LogResponseDto::from);
     }
 
     /** 로그 상세 조회
      *
-     * @param id
+     * @param user
+     * @param logId
      * @return LogResponseDto
      */
-    public LogResponseDto getLogDetail(Long id) {
-        Log log = logRepository.findByIdOrThrow(id);
+    public LogResponseDto getLogDetail(User user, Long logId) {
+        Log log = logRepository.findByIdOrThrow(logId);
 
-        return new LogResponseDto(
-                log.getId(),
-                log.getLogLevel(),
-                log.getExceptionName(),
-                log.getErrorCodeMessage(),
-                log.getMessage(),
-                log.getStackSummary(),
-                log.getTimestamp()
-        );
+        Long projectId = log.getProjectIdLegacy();
+
+        if (projectId == null) {
+            checkAdminRole(user); // 프로젝트 없으면 관리자만 조회 가능
+            return LogResponseDto.from(log);
+        }
+
+        Project project = getProjectAllowDeleted(projectId);
+
+        if (user.getRole().equals(UserRoleEnum.ADMIN)) {
+            return LogResponseDto.from(log); // 서버 관리자는 무조건 가능
+        }
+
+        checkAccessToProjectLogs(user, project);
+
+        return LogResponseDto.from(log);
     }
 
     /** 로그 통계 조회
      *
+     * @param user
+     * @param projectId
      * @param start
      * @param end
      * @return List<LogStatisticsDto>
      */
-    public List<LogStatisticsDto> getLogStatistics(LocalDateTime start, LocalDateTime end) {
-        return logRepository.countGroupByLogLevel(start, end)
-                .stream()
-                .map(record -> new LogStatisticsDto((LogLevel) record[0], (Long) record[1]))
-                .toList();
+    public List<LogStatisticsDto> getLogStatistics(User user, Long projectId, LocalDateTime start, LocalDateTime end) {
+        if (projectId == null) {
+            checkAdminRole(user); // 전체 통계 조회는 관리자만 가능
+
+            return logRepository.countGroupByLogLevel(start, end)
+                    .stream()
+                    .map(record -> new LogStatisticsDto((LogLevel) record[0], (Long) record[1]))
+                    .toList();
+        } else {
+            Project project = getProjectAllowDeleted(projectId);
+
+            checkAccessToProjectLogs(user, project);
+
+            return logRepository.countGroupByProjectIdAndLogLevel(projectId, start, end)
+                    .stream()
+                    .map(record -> new LogStatisticsDto((LogLevel) record[0], (Long) record[1]))
+                    .toList();
+        }
+    }
+
+    /** 프로젝트 조회 (삭제된 프로젝트 포함) */
+    private Project getProjectAllowDeleted(Long projectId) {
+        return projectRepository.findAnyById(projectId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND, projectId, "PROJECT"));
+    }
+
+    /** 관리자 여부 체크, 아니면 예외 던짐 */
+    private void checkAdminRole(User user) {
+        if (!user.getRole().equals(UserRoleEnum.ADMIN)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED, null);
+        }
+    }
+
+    /** 프로젝트 로그 접근 권한 체크 */
+    private void checkAccessToProjectLogs(User user, Project project) {
+        Long userId = user.getId();
+
+        boolean isProjectCreator = project.getCreatedBy().getId().equals(userId);
+        boolean isAdmin = user.getRole().equals(UserRoleEnum.ADMIN);
+        boolean isTeamAdmin = project.getTeam().getUserTeams().stream()
+                .anyMatch(userTeam -> userTeam.getUser().getId().equals(userId) && userTeam.getRole() == TeamRole.ADMIN);
+
+        if (!(isProjectCreator || isAdmin || isTeamAdmin)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED, null);
+        }
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/develop/logsentry/domain/project/repository/ProjectRepository.java
@@ -4,6 +4,8 @@ import com.develop.logsentry.common.exception.CustomException;
 import com.develop.logsentry.common.exception.ErrorCode;
 import com.develop.logsentry.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,20 +19,23 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     Optional<Project> findByApiKeyAndIsActiveTrue(String apiKey);
 
     default Project findByIdOrThrow(Long id) {
-        return findById(id).orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND, "PROJECT", id));
+        return findById(id).orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND, id, "PROJECT", id));
     }
 
     default void existsByIdAndCreatedByIdOrThrow(Long projectId, Long userId) {
         if (!existsByIdAndCreatedById(projectId, userId)) {
-            throw new CustomException(ErrorCode.NO_PROJECT_OWNER_PRIVILEGE, "PROJECT");
+            throw new CustomException(ErrorCode.NO_PROJECT_OWNER_PRIVILEGE, projectId, "PROJECT");
         }
     }
 
     default Project findByIdAndIsActiveTrueOrThrow(Long projectId) {
-        return findByIdAndIsActiveTrue(projectId).orElseThrow(() -> new CustomException(ErrorCode.PROJECT_INACTIVE, "PROJECT"));
+        return findByIdAndIsActiveTrue(projectId).orElseThrow(() -> new CustomException(ErrorCode.PROJECT_INACTIVE, projectId, "PROJECT"));
     }
 
     default Project findByApiKeyAndIsActiveTrueOrThrow(String apiKey) {
-        return findByApiKeyAndIsActiveTrue(apiKey).orElseThrow(() -> new CustomException(ErrorCode.INVALID_API_KEY, "PROJECT"));
+        return findByApiKeyAndIsActiveTrue(apiKey).orElseThrow(() -> new CustomException(ErrorCode.INVALID_API_KEY, null, "PROJECT"));
     }
+
+    @Query(value = "SELECT * FROM project WHERE id = :id", nativeQuery = true)
+    Optional<Project> findAnyById(@Param("id") Long id);
 }

--- a/src/main/java/com/develop/logsentry/domain/project/service/ProjectService.java
+++ b/src/main/java/com/develop/logsentry/domain/project/service/ProjectService.java
@@ -1,7 +1,6 @@
 package com.develop.logsentry.domain.project.service;
 
-import com.develop.logsentry.common.exception.CustomException;
-import com.develop.logsentry.common.exception.ErrorCode;
+import com.develop.logsentry.domain.log.repository.LogRepository;
 import com.develop.logsentry.domain.project.dto.request.ProjectRequestDto;
 import com.develop.logsentry.domain.project.dto.request.ProjectUpdateRequestDto;
 import com.develop.logsentry.domain.project.dto.response.ApiKeyResponseDto;
@@ -11,7 +10,6 @@ import com.develop.logsentry.domain.project.dto.response.ProjectResponseDto;
 import com.develop.logsentry.domain.project.entity.Project;
 import com.develop.logsentry.domain.project.repository.ProjectRepository;
 import com.develop.logsentry.domain.team.entity.Team;
-import com.develop.logsentry.domain.team.entity.TeamRole;
 import com.develop.logsentry.domain.team.repository.TeamRepository;
 import com.develop.logsentry.domain.user.entity.User;
 import com.develop.logsentry.domain.user.entity.UserTeam;
@@ -21,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,6 +31,7 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
+    private final LogRepository logRepository;
 
     /**
      * 프로젝트 생성
@@ -47,10 +47,6 @@ public class ProjectService {
 
         Team team = teamRepository.findByIdOrThrow(teamId);
         UserTeam userTeam = userTeamRepository.findByTeamIdAndUserIdOrThrow(teamId, user.getId());
-
-        if (userTeam.getRole() != TeamRole.ADMIN) {
-            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, "PROJECT");
-        }
 
         Project project = Project.builder()
                 .team(team)
@@ -155,7 +151,7 @@ public class ProjectService {
         userTeamRepository.findByTeamIdAndUserIdOrThrow(teamId, user.getId());
 
         int teamMemberCount = userTeamRepository.countByTeamId(teamId);
-        int recentLogCount = 0; // logRepository.countByProjectIdAndCreatedAtAfter(...)
+        int recentLogCount = (int) logRepository.countByProjectIdLegacyAndTimestampAfter(projectId, LocalDateTime.now().minusDays(7));
         int apiKeyUsageCount = 0; // apiKeyUsageRepository.countByProjectId(...)
 
         return new ProjectDashboardResponseDto(

--- a/src/main/java/com/develop/logsentry/domain/team/repository/InvitationRepository.java
+++ b/src/main/java/com/develop/logsentry/domain/team/repository/InvitationRepository.java
@@ -16,11 +16,11 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
     default void throwIfAlreadyInvited(String email, Team team) {
         if (existsByEmailAndTeam(email, team)) {
-            throw new CustomException(ErrorCode.ALREADY_INVITED, "INVITATION");
+            throw new CustomException(ErrorCode.ALREADY_INVITED, null, "INVITATION");
         }
     }
 
     default Invitation findByInviteTokenOrThrow(String token) {
-        return findByInviteToken(token).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INVITATION_TOKEN, "INVITATION"));
+        return findByInviteToken(token).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INVITATION_TOKEN, null, "INVITATION"));
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/develop/logsentry/domain/team/repository/TeamRepository.java
@@ -15,11 +15,11 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     default void throwIfNameExists(String name) {
         if (existsByName(name)) {
-            throw new CustomException(ErrorCode.TEAM_ALREADY_EXISTS, name);
+            throw new CustomException(ErrorCode.TEAM_ALREADY_EXISTS, null, name);
         }
     }
 
     default Team findByIdOrThrow(Long id) {
-        return findById(id).orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND, "TEAM"));
+        return findById(id).orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND, null, "TEAM"));
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/team/service/InvitationService.java
+++ b/src/main/java/com/develop/logsentry/domain/team/service/InvitationService.java
@@ -29,11 +29,11 @@ public class InvitationService {
         Invitation invitation = invitationRepository.findByInviteTokenOrThrow(token);
 
         if (invitation.isAccepted()) {
-            throw new CustomException(ErrorCode.ALREADY_INVITED, "INVITATION");
+            throw new CustomException(ErrorCode.ALREADY_INVITED, null, "INVITATION");
         }
 
         if (!invitation.getEmail().equals(user.getEmail())) {
-            throw new CustomException(ErrorCode.EMAIL_NOT_MATCH, "INVITATION");
+            throw new CustomException(ErrorCode.EMAIL_NOT_MATCH, null, "INVITATION");
         }
 
         userTeamRepository.throwIfTeamIdAndUserIdExists(invitation.getTeam().getId(), user.getId());

--- a/src/main/java/com/develop/logsentry/domain/team/service/TeamService.java
+++ b/src/main/java/com/develop/logsentry/domain/team/service/TeamService.java
@@ -98,7 +98,7 @@ public class TeamService {
         UserTeam inviterTeamRole = userTeamRepository.findByTeamIdAndUserIdOrThrow(teamId, inviter.getId());
 
         if (inviterTeamRole.getRole() != TeamRole.ADMIN) {
-            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, "TEAM");
+            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, null, "TEAM");
         }
 
         Optional<User> optionalUser = userRepository.findByEmailAndIsActiveTrue(inviteRequestDto.getEmail());
@@ -157,7 +157,7 @@ public class TeamService {
     public UpdateMemberResponseDto updateTeamMemberRole(Long teamId, Long targetUserId, String newRole, User user) {
         UserTeam admin = userTeamRepository.findByTeamIdAndUserIdOrThrow(teamId, user.getId());
         if (admin.getRole() != TeamRole.ADMIN) {
-            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, "TEAM");
+            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, null, "TEAM");
         }
 
         UserTeam target = userTeamRepository.findByTeamIdAndUserIdOrThrow(teamId, targetUserId);
@@ -176,7 +176,7 @@ public class TeamService {
     public void deleteTeam(Long teamId, User adminUser) {
         UserTeam admin = userTeamRepository.findByTeamIdAndUserIdOrThrow(teamId, adminUser.getId());
         if (admin.getRole() != TeamRole.ADMIN) {
-            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, "TEAM");
+            throw new CustomException(ErrorCode.NO_TEAM_ADMIN_PRIVILEGE, null, "TEAM");
         }
 
         Team team = teamRepository.findByIdOrThrow(teamId);

--- a/src/main/java/com/develop/logsentry/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/develop/logsentry/domain/user/repository/UserRepository.java
@@ -16,17 +16,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     default void throwIfEmailExists(String email) {
         if (existsByEmail(email)) {
-            throw new CustomException(ErrorCode.USER_ALREADY_EXISTS, email);
+            throw new CustomException(ErrorCode.USER_ALREADY_EXISTS, null, email);
         }
     }
 
     default void throwIfUsernameExists(String username) {
         if (existsByUsername(username)) {
-            throw new CustomException(ErrorCode.USERNAME_ALREADY_EXISTS, username);
+            throw new CustomException(ErrorCode.USERNAME_ALREADY_EXISTS, null, username);
         }
     }
 
     default User findByEmailAndIsActiveTrueOrThrow(String email) {
-        return findByEmailAndIsActiveTrue(email).orElseThrow(() -> new CustomException(ErrorCode.USER_INACTIVE, "USER"));
+        return findByEmailAndIsActiveTrue(email).orElseThrow(() -> new CustomException(ErrorCode.USER_INACTIVE, null, "USER"));
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/user/repository/UserTeamRepository.java
+++ b/src/main/java/com/develop/logsentry/domain/user/repository/UserTeamRepository.java
@@ -19,12 +19,12 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     boolean existsByTeamIdAndUserId(Long teamId, Long userId);
 
     default UserTeam findByTeamIdAndUserIdOrThrow(Long teamId, Long userId) {
-        return findByTeamIdAndUserId(teamId, userId).orElseThrow(() -> new CustomException(ErrorCode.TEAM_ACCESS_DENIED, "USER_TEAM"));
+        return findByTeamIdAndUserId(teamId, userId).orElseThrow(() -> new CustomException(ErrorCode.TEAM_ACCESS_DENIED, null, "USER_TEAM"));
     }
 
     default void throwIfTeamIdAndUserIdExists(Long teamId, Long userId) {
         if(existsByTeamIdAndUserId(teamId, userId)) {
-            throw new CustomException(ErrorCode.USER_ALREADY_IN_TEAM, "USER_TEAM");
+            throw new CustomException(ErrorCode.USER_ALREADY_IN_TEAM, null, "USER_TEAM");
         }
     }
 }

--- a/src/main/java/com/develop/logsentry/domain/user/service/UserService.java
+++ b/src/main/java/com/develop/logsentry/domain/user/service/UserService.java
@@ -52,7 +52,7 @@ public class UserService {
             if (inputAdminKey.equals(adminKey)) {
                 role = UserRoleEnum.ADMIN;
             } else {
-                throw new CustomException(ErrorCode.INVALID_ADMIN_KEY, "USER");
+                throw new CustomException(ErrorCode.INVALID_ADMIN_KEY, null, "USER");
             }
         }
 
@@ -96,7 +96,7 @@ public class UserService {
      * @return UserProfileResponseDto
      */
     public UserProfileResponseDto getMyProfile(User user) {
-        if (user == null) { throw new CustomException(ErrorCode.USER_NOT_FOUND, "USER");}
+        if (user == null) { throw new CustomException(ErrorCode.USER_NOT_FOUND, null, "USER");}
 
         return new UserProfileResponseDto(user.getId(), user.getEmail(), user.getUsername(), List.of(user.getRole()));
     }
@@ -118,7 +118,7 @@ public class UserService {
     // 비밀번호 확인
     private void checkPassword(String rawPassword, String encodedPassword) {
         if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-            throw new CustomException(ErrorCode.INVALID_CREDENTIALS, "USER");
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS, null, "USER");
         }
     }
 }


### PR DESCRIPTION
- [x] Add projectIdLegacy field to Log entity
- [x] Modify Kafka consumer to persist project ID
- [x] Update LogRepository methods to support filtering by project

----------------------------------------------------------------------------------------------

- [x] Allow ADMIN to access all logs
- [x] Allow project creators and team admins to access related project logs
- [x] Apply access rules in log search, detail, and statistics endpoints